### PR TITLE
chore: align schedule for building images with Bazzite/Aurorafin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,11 @@ on:
     branches:
       - main
   schedule:
-    # 6:00 UTC Monday
-    # - Bazzite is built 4:40 utc monday
+    # 7:10 UTC Monday
+    # - Bazzite is built 4:40 utc Monday and takes roughly 90 minutes
+    #   so this schedule gives about an hour wiggle room
     # - Bluefin/Aurora are built everyday at 4:40 utc as well
-    - cron: "00 6 * * 1" # 4:40 utc monday
+    - cron: "10 7 * * 1" # 4:40 utc monday
   push:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,10 @@ on:
     branches:
       - main
   schedule:
-    - cron: "05 10 * * *" # 10:05am UTC everyday
+    # 6:00 UTC Monday
+    # - Bazzite is built 4:40 utc monday
+    # - Bluefin/Aurora are built everyday at 4:40 utc as well
+    - cron: "00 6 * * 1" # 4:40 utc monday
   push:
     branches:
       - main


### PR DESCRIPTION
This changes the build to kick off roughly an hour after Bazzite is finished.

Closes #5 