### PR TITLE
fix: Store runtime dependant var-opt to share/factory

### DIFF
--- a/build_files/fix-opt.sh
+++ b/build_files/fix-opt.sh
@@ -9,12 +9,10 @@ log() {
 
 log "Starting /opt directory fix"
 
-# Move directories from /var/opt to /usr/lib/opt
-for dir in /var/opt/*/; do
-  [ -d "$dir" ] || continue
-  dirname=$(basename "$dir")
-  mv "$dir" "/usr/lib/opt/$dirname"
-  echo "L+ /var/opt/$dirname - - - - /usr/lib/opt/$dirname" >>/usr/lib/tmpfiles.d/amyos-opt-fix.conf
-done
+# Move /var/opt to /usr/share/factory/opt
+mkdir -p /usr/share/factory/var/opt
+mv -Tv /var/opt /usr/lib/opt
+mkdir -p /var/opt # Recreate an empty dir, just in case
+echo "C+ /var/opt - - - - /usr/share/factory/var/opt" >>/usr/lib/tmpfiles.d/bazzite-factory-opt.conf
 
 log "Fix completed"


### PR DESCRIPTION
More compliant with file system hierarchy than by using usr/lib/opt