### PR TITLE
docs: add valid URL for bluefin/aurora mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Bazzite DX](https://github.com/ublue-os/bazzite-dx/actions/workflows/build.yml/badge.svg)](https://github.com/ublue-os/bazzite-dx/actions/workflows/build.yml)
 
-This is just bazzite, but with extra developer-specific tooling, aiming to match [Bluefin DX]() and [Aurora DX]() in functionality
+This is just bazzite, but with extra developer-specific tooling, aiming to match [Bluefin DX](https://docs.projectbluefin.io/bluefin-dx/) and [Aurora DX](https://docs.getaurora.dev/guides/developer/) in functionality
 
 `bazzite-gdx` will source from here and be focused for game development. 
 


### PR DESCRIPTION
I forgot to add this on the previous PR, these are just references as to what this `-dx` edition should be like