### PR TITLE
ci: remove the labeled gate for the `safe-to-run` tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
     - cron: "10 7 * * 1" # 4:40 utc monday
   merge_group:
   pull_request:
-    types: [labeled]
   workflow_dispatch:
 
 env:
@@ -38,9 +37,6 @@ jobs:
       # These stage versions are pinned by https://github.com/renovatebot/renovate
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       # This is optional, but if you see that your builds are way too big for the runners, you can enable this by uncommenting the following lines:
       # - name: Maximize build space


### PR DESCRIPTION
We just want to get the PR workflows going right now, we can re-add it after talking to everyone later