### PR TITLE
feat: add extensions installer hook for vscode

### DIFF
--- a/build_files/40-services.sh
+++ b/build_files/40-services.sh
@@ -3,3 +3,5 @@ set -xeuo pipefail
 
 systemctl enable docker.socket
 systemctl enable podman.socket
+systemctl enable ublue-system-setup.service
+systemctl --global enable ublue-user-setup.service

--- a/system_files/usr/share/ublue-os/user-setup.hooks.d/11-vscode-extensions.sh
+++ b/system_files/usr/share/ublue-os/user-setup.hooks.d/11-vscode-extensions.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/bash
+
+source /usr/lib/ublue/setup-services/libsetup.sh
+
+version-script vscode-extensions-dx user 1 || exit 1
+
+set -x
+
+# Setup VSCode
+if test ! -e "$HOME"/.config/Code/User/settings.json; then
+	mkdir -p "$HOME"/.config/Code/User
+	cp -f /etc/skel/.config/Code/User/settings.json "$HOME"/.config/Code/User/settings.json
+fi
+
+code --install-extension ms-vscode-remote.remote-containers
+code --install-extension ms-vscode-remote.remote-ssh
+code --install-extension ms-azuretools.vscode-docker


### PR DESCRIPTION
This includes the same set up script we have for VSCode on Bluefin LTS, with Docker, Devcontainers and Remote access extensions by default + the default config

"Why the draft?" We need to enable the ublue-user-setup service, lemme just find this
