### PR TITLE
chore: Pull in ccache

### DIFF
--- a/build_files/20-install-apps.sh
+++ b/build_files/20-install-apps.sh
@@ -10,6 +10,7 @@ dnf5 install -y \
     bpftop \
     bpftrace \
     flatpak-builder \
+    ccache \
     nicstat \
     numactl \
     podman-machine \


### PR DESCRIPTION
- Not being pulled with `flatpak-builder`, for whatever reason.
