### PR TITLE
feat: add -deck images to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
           - bazzite-gnome-nvidia-open
           - bazzite-nvidia-open
           - bazzite-deck
+          - bazzite-deck-gnome
+          - bazzite-deck-nvidia-gnome
           - bazzite-deck-nvidia
 
     env:

--- a/README.md
+++ b/README.md
@@ -41,9 +41,19 @@ rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-dx-gnome-n
 rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-dx-deck:stable
 ```
 
-**For HTPCs with NVIDIA GPU:**
+**For GNOME:**
+```bash
+rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-dx-deck-gnome:stable
+```
+
+**For KDE with NVIDIA GPU:**
 ```bash
 rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-dx-deck-nvidia:stable
+```
+
+**For GNOME with NVIDIA GPU:**
+```bash
+rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-dx-deck-nvidia-gnome:stable
 ```
 
 ### ⚠️ Important Desktop Environment Warning


### PR DESCRIPTION
Add builds for bazzite-dx atop the following deck images, for those who want a primarily handheld or HTPC controller-driven OS, with the option to dev here and there:

- bazzite-deck
- bazzite-deck-gnome
- bazzite-deck-nvidia
- bazzite-deck-nvidia-gnome

Also, uncommented the "Maximize build space" portion of the build workflow to resolve "no space left on device" errors in some image builds.