### PR TITLE
feat: Simplify builds by dropping -deck and keeping gamemode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,10 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         base_image:
-          - bazzite
-          - bazzite-gnome
-          - bazzite-gnome-nvidia-open
-          - bazzite-nvidia-open
           - bazzite-deck
           - bazzite-deck-gnome
           - bazzite-deck-nvidia-gnome
@@ -111,7 +107,7 @@ jobs:
       - name: Generate output image ref
         id: gen_image_ref
         run: |
-          echo "IMAGE_NAME=${BASE_IMAGE/bazzite/bazzite-dx}" | tee -a $GITHUB_ENV
+          echo "IMAGE_NAME=${BASE_IMAGE/bazzite/bazzite-dx}" | sed 's/-deck//' | tee -a "$GITHUB_ENV"
 
       # Image metadata for https://artifacthub.io/ - This is optional but is highly recommended so we all can get a index of all the custom images
       # The metadata by itself is not going to do anything, you choose if you want your image to be on ArtifactHub or not.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ This is just bazzite, but with extra developer-specific tooling, aiming to match
 
 To rebase an existing Bazzite installation to Bazzite DX, use one of the following commands based on your current variant:
 
-### Desktop Variants
-
 **For KDE Plasma (default Bazzite):**
 ```bash
 rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-dx:stable
@@ -32,28 +30,6 @@ rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-dx-nvidia-
 **For GNOME with NVIDIA:**
 ```bash
 rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-dx-gnome-nvidia-open:stable
-```
-
-### Handheld & HTPC Variants
-
-**For KDE:**
-```bash
-rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-dx-deck:stable
-```
-
-**For GNOME:**
-```bash
-rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-dx-deck-gnome:stable
-```
-
-**For KDE with NVIDIA GPU:**
-```bash
-rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-dx-deck-nvidia:stable
-```
-
-**For GNOME with NVIDIA GPU:**
-```bash
-rpm-ostree rebase ostree-unverified-registry:ghcr.io/ublue-os/bazzite-dx-deck-nvidia-gnome:stable
 ```
 
 ### ⚠️ Important Desktop Environment Warning

--- a/build_files/20-install-apps.sh
+++ b/build_files/20-install-apps.sh
@@ -21,9 +21,9 @@ dnf5 install -y \
     zsh
 
 # Remove -deck specific changes to allow for login screens
-rm /etc/sddm.conf.d/steamos.conf
-rm /etc/sddm.conf.d/virtualkbd.conf
-rm /usr/share/gamescope-session-plus/bootstrap_steam.tar.gz
+rm -f /etc/sddm.conf.d/steamos.conf
+rm -f /etc/sddm.conf.d/virtualkbd.conf
+rm -f /usr/share/gamescope-session-plus/bootstrap_steam.tar.gz
 systemctl disable bazzite-autologin.service
 
 if [[ "$IMAGE_NAME" == *gnome* ]]; then

--- a/build_files/20-install-apps.sh
+++ b/build_files/20-install-apps.sh
@@ -22,7 +22,9 @@ dnf5 install -y \
 
 # Remove -deck specific changes to allow for login screens
 rm /etc/sddm.conf.d/steamos.conf
-systemctl disable bazzite-autologin.service && \
+rm /etc/sddm.conf.d/virtualkbd.conf
+systemctl disable bazzite-autologin.service
+
 if [[ "$IMAGE_NAME" == *-gnome* ]]; then
     dnf5 remove -y \
         sddm

--- a/build_files/20-install-apps.sh
+++ b/build_files/20-install-apps.sh
@@ -23,6 +23,7 @@ dnf5 install -y \
 # Remove -deck specific changes to allow for login screens
 rm /etc/sddm.conf.d/steamos.conf
 rm /etc/sddm.conf.d/virtualkbd.conf
+rm /usr/share/gamescope-session-plus/bootstrap_steam.tar.gz
 systemctl disable bazzite-autologin.service
 
 if [[ "$IMAGE_NAME" == *gnome* ]]; then

--- a/build_files/20-install-apps.sh
+++ b/build_files/20-install-apps.sh
@@ -25,7 +25,7 @@ rm /etc/sddm.conf.d/steamos.conf
 rm /etc/sddm.conf.d/virtualkbd.conf
 systemctl disable bazzite-autologin.service
 
-if [[ "$IMAGE_NAME" == *-gnome* ]]; then
+if [[ "$IMAGE_NAME" == *gnome* ]]; then
     dnf5 remove -y \
         sddm
 

--- a/build_files/20-install-apps.sh
+++ b/build_files/20-install-apps.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/bash
 set -xeuo pipefail
 
-mkdir -p /usr/share/gamescope-session-plus/
-curl -Lo /usr/share/gamescope-session-plus/bootstrap_steam.tar.gz https://large-package-sources.nobaraproject.org/bootstrap_steam.tar.gz
-dnf5 install --enable-repo="copr:copr.fedorainfracloud.org:bazzite-org:bazzite" -y \
-    gamescope-session-plus \
-    gamescope-session-steam
-
 dnf5 install -y \
     android-tools \
     bcc \
@@ -25,6 +19,17 @@ dnf5 install -y \
     sysprof \
     tiptop \
     zsh
+
+# Remove -deck specific changes to allow for login screens
+rm /etc/sddm.conf.d/steamos.conf
+systemctl disable bazzite-autologin.service && \
+if [[ "$IMAGE_NAME" == *-gnome* ]]; then
+    dnf5 remove -y \
+        sddm
+
+    systemctl enable gdm.service
+fi
+
 
 dnf5 install --enable-repo="copr:copr.fedorainfracloud.org:ublue-os:packages" -y \
     ublue-setup-services


### PR DESCRIPTION
Continuation of https://github.com/ublue-os/bazzite-dx/pull/94

This PR seeks to eliminate numerous DX images by dropping the -deck builds. Instead, bazzite-dx is now exclusively built *from* -deck images, and then the autologin stuff is removed to expose a normal login screen once more on that image type.

This solves all issues -- they can still be used like a desktop, they can still be used on a handheld, and they don't needlessly bloat our build matrix.