### PR TITLE
feat: Add libimobiledevice-utils to the dx image for interacting with iDevices

### DIFF
--- a/build_files/20-install-apps.sh
+++ b/build_files/20-install-apps.sh
@@ -19,6 +19,7 @@ dnf5 install -y \
     sysprof \
     tiptop \
     usbmuxd \
+    libimobiledevice-utils \
     zsh
 
 # Restore UUPD update timer and Input Remapper


### PR DESCRIPTION
From what I have seen, libimobiledevice-utils seems to be recommended as well.

https://www.reddit.com/r/Bazzite/comments/1k50oj6/comment/mquy7w4/

<img width="1052" height="282" alt="image" src="https://github.com/user-attachments/assets/990d18ef-6b75-4d60-af75-0a9afc65d90d" />
