### PR TITLE
fix: Remove leftover deck file that forces game mode on autologin

### DIFF
--- a/build_files/20-install-apps.sh
+++ b/build_files/20-install-apps.sh
@@ -26,15 +26,13 @@ sed -i 's@^NoDisplay=true@NoDisplay=false@' /usr/share/applications/input-remapp
 systemctl enable input-remapper.service
 systemctl enable uupd.timer
 
-# Remove -deck specific changes to allow for login screens
+# Remove -deck specific changes to allow for login screens and session selection in settings
 rm -f /etc/sddm.conf.d/steamos.conf
 rm -f /etc/sddm.conf.d/virtualkbd.conf
+rm -f /etc/sddm.conf.d/zz-steamos-autologin.conf
 rm -f /usr/share/gamescope-session-plus/bootstrap_steam.tar.gz
 systemctl disable bazzite-autologin.service
 dnf5 remove -y steamos-manager
-
-# Remove -deck specific autologin to allow for selection of session in KDE settings
-rm -f /etc/sddm.conf.d/zz-steamos-autologin.conf
 
 if [[ "$IMAGE_NAME" == *gnome* ]]; then
     # Remove SDDM and re-enable GDM on GNOME builds.


### PR DESCRIPTION
Fix for #142 - removing the file that stops the user preference being respected.