### PR TITLE
chore: replace rebase commands to brh

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,27 +12,25 @@ To rebase an existing Bazzite installation to Bazzite DX, use one of the followi
 
 **For KDE Plasma (default Bazzite):**
 ```bash
-rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/bazzite-dx:stable
+brh rebase bazzite-dx:stable
 ```
 
 **For GNOME:**
 ```bash
-rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/bazzite-dx-gnome:stable
+brh rebase bazzite-dx-gnome:stable
 ```
 
 ### NVIDIA Variants
 
 **For KDE Plasma with NVIDIA:**
 ```bash
-rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/bazzite-dx-nvidia:stable
+brh rebase bazzite-dx-nvidia:stable
 ```
 
 **For GNOME with NVIDIA:**
 ```bash
-rpm-ostree rebase ostree-image-signed:docker://ghcr.io/ublue-os/bazzite-dx-nvidia-gnome:stable
+brh rebase bazzite-dx-nvidia-gnome:stable
 ```
-
-To skip signature verification (not recommended unless you know what you're doing and why you're doing it), replace `ostree-image-signed:docker://ghcr.io` with `ostree-unverified-registry:ghcr.io`.
 
 ### ⚠️ Important Desktop Environment Warning
 


### PR DESCRIPTION
It's much easier to type manually and users don't have to copy-paste old commands. I also removed a note about unverified images since it's not preferred to use and MOTD encourages users to rebase to verified one anyway.

Related https://github.com/ublue-os/dev.bazzite.gg/pull/6