### PR TITLE
chore(build): Build at 5:40 UTC on Mondays

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 ---
 name: Build Bazzite DX
 on:
+  schedule:
+    - cron: "40 5 * * 1" # 5:40 utc monday
   repository_dispatch:
     types:
       - build


### PR DESCRIPTION
One hour after Bazzite. Noticed most builds up to now have been manually triggered or triggered on merge. Let's fix that