### PR TITLE
fix: small bug cleanup across Containerfile, build scripts, and Justfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,7 +8,7 @@ COPY build_files /build_files
 FROM ${BASE_IMAGE}
 
 ARG IMAGE_NAME="${IMAGE_NAME:-bazzite-dx}"
-ARG IMAGE_VENDOR="{IMAGE_VENDOR:-ublue-os}"
+ARG IMAGE_VENDOR="${IMAGE_VENDOR:-ublue-os}"
 
 RUN --mount=type=tmpfs,dst=/tmp \
   --mount=type=bind,from=ctx,source=/,target=/run/context \

--- a/Justfile
+++ b/Justfile
@@ -69,7 +69,7 @@ build $target_image=image_name $tag=default_tag:
     ${PODMAN} build \
       "${BUILD_ARGS[@]}" \
       --pull=newer \
-      --tag "${image_name}:${tag}" \
+      --tag "${target_image}:${tag}" \
       .
 
 _rootful_load_image $target_image=image_name $tag=default_tag:

--- a/build_files/20-install-apps.sh
+++ b/build_files/20-install-apps.sh
@@ -94,7 +94,7 @@ dnf5 config-manager addrepo --from-repofile="https://download.docker.com/linux/f
 dnf5 config-manager setopt docker-ce-stable.enabled=0
 dnf5 install -y --enable-repo="docker-ce-stable" "${docker_pkgs[@]}" || {
     # Use test packages if docker pkgs is not available for f42
-    if (($(lsb_release -sr) == 42)); then
+    if [[ "${MAJOR_VERSION_NUMBER}" == "42" ]]; then
         echo "::info::Missing docker packages in f42, falling back to test repos..."
         dnf5 install -y --enablerepo="docker-ce-test" "${docker_pkgs[@]}"
     fi

--- a/build_files/50-fix-opt.sh
+++ b/build_files/50-fix-opt.sh
@@ -10,6 +10,7 @@ log() {
 log "Starting /opt directory fix"
 
 # Move directories from /var/opt to /usr/lib/opt
+mkdir -p /usr/lib/opt
 for dir in /var/opt/*/; do
   [ -d "$dir" ] || continue
   dirname=$(basename "$dir")

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 CONTEXT_PATH="$(realpath "$(dirname "$0")/..")" # should return /run/context
-BUILD_SCRIPTS_PATH="$(realpath "$(dirname $0)")"
+BUILD_SCRIPTS_PATH="$(realpath "$(dirname "$0")")"
 MAJOR_VERSION_NUMBER="$(sh -c '. /usr/lib/os-release ; echo $VERSION_ID')"
 SCRIPTS_PATH="$(realpath "$(dirname "$0")/scripts")"
 export CONTEXT_PATH

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -1,5 +1,0 @@
-images:
-  - name: bazzite-deck
-    image: ghcr.io/ublue-os/bazzite-deck
-    tag: stable
-    digest: sha256:650e55225942a7bc920cdc30aacfd5766e7e141a9661f3628a38e9e91b4556b5


### PR DESCRIPTION
## Summary

Two commits' worth of small, low-risk fixes. All align with upstream ublue-os/bazzite where applicable.

## Changes

### `472a2af4` — IMAGE_VENDOR default + stale image-versions.yaml
- **Containerfile**: `IMAGE_VENDOR` ARG was missing the leading `$` (`{IMAGE_VENDOR:-ublue-os}` instead of `${IMAGE_VENDOR:-ublue-os}`). The `"ublue-os"` default never took effect, so every build produced images with an empty vendor string unless `IMAGE_VENDOR` was explicitly passed via `--build-arg`. This affected all downstream metadata (`/usr/share/ublue-os/image-info.json`).
- **image-versions.yaml**: deleted — pinned a stale `bazzite-deck:stable` digest from an older upstream build. Not referenced by any build script, CI workflow, or Containerfile. Already removed upstream.

### `7465d154` — small bugs in build scripts and Justfile
- **Justfile** (`build` recipe): now honors the `$target_image` parameter. Previously the recipe accepted `$target_image=image_name` but always tagged `${image_name}:${tag}`, silently ignoring overrides like `just build localhost/foo`.
- **build_files/20-install-apps.sh**: F42 docker fallback used `lsb_release -sr`, but `lsb_release` isn't installed on bootc base images. Switched to `${MAJOR_VERSION_NUMBER}` which is already exported by `build.sh`.
- **build_files/50-fix-opt.sh**: added `mkdir -p /usr/lib/opt` before the move loop. Without it, the first iteration renames `/var/opt/<x>` to `/usr/lib/opt` instead of moving it inside, and subsequent iterations fail.
- **build_files/build.sh**: quoted `$0` in `dirname` call (shellcheck SC2086).

## Files Changed

| File | Change |
|---|---|
| `Containerfile` | 1-char fix (`$` prefix) |
| `image-versions.yaml` | Deleted |
| `Justfile` | 1 line |
| `build_files/20-install-apps.sh` | 1 line |
| `build_files/50-fix-opt.sh` | 1 line added |
| `build_files/build.sh` | 1 line |

## Testing

CI matrix builds all 4 variants (`bazzite-deck`, `bazzite-deck-gnome`, `bazzite-deck-nvidia-gnome`, `bazzite-deck-nvidia`).

- [ ] Each variant shows `IMAGE_VENDOR=ublue-os` in `/usr/share/ublue-os/image-info.json`
- [ ] Build completes the docker-ce step without invoking the F42 fallback (current base is F43)
- [ ] `just build` and `just build localhost/custom` produce correctly-tagged images locally

## Related Issues

None.