### PR TITLE
fix(iso): make ISO post-install bootc switch target variant-aware

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -2,6 +2,7 @@ export repo_organization := env("GITHUB_REPOSITORY_OWNER", "ublue-os")
 export image_name := env("IMAGE_NAME", "bazzite-dx")
 export default_tag := env("DEFAULT_TAG", "latest")
 export bib_image := env("BIB_IMAGE", "quay.io/centos-bootc/bootc-image-builder:latest")
+export iso_ref_tag := env("ISO_REF_TAG", "latest")
 export SUDO_DISPLAY := if `if [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then echo true; fi` == "true" { "true" } else { "false" }
 export SUDOIF := if `id -u` == "0" { "" } else if SUDO_DISPLAY == "true" { "sudo --askpass" } else { "sudo" }
 export PODMAN := if path_exists("/usr/bin/podman") == "true" { env("PODMAN", "/usr/bin/podman") } else if path_exists("/usr/bin/docker") == "true" { env("PODMAN", "docker") } else { env("PODMAN", "exit 1 ; ") }
@@ -143,8 +144,20 @@ build-qcow2 $target_image=("localhost/" + image_name) $tag=default_tag: && (_bui
 [group('Build Virtual Machine Image')]
 build-raw $target_image=("localhost/" + image_name) $tag=default_tag: && (_build-bib target_image tag "raw" "image.toml")
 
+# Render iso.toml.in into _build_iso/iso.toml using IMAGE_VENDOR/IMAGE_NAME/ISO_REF_TAG
+[private]
+_render-iso-config:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p _build_iso
+    IMAGE_VENDOR="${repo_organization}" \
+      IMAGE_NAME="${image_name}" \
+      ISO_REF_TAG="${iso_ref_tag}" \
+      envsubst '${IMAGE_VENDOR} ${IMAGE_NAME} ${ISO_REF_TAG}' \
+        < iso.toml.in > _build_iso/iso.toml
+
 [group('Build Virtual Machine Image')]
-build-iso $target_image=("localhost/" + image_name) $tag=default_tag: && (_build-bib target_image tag "iso" "iso.toml")
+build-iso $target_image=("localhost/" + image_name) $tag=default_tag: _render-iso-config && (_build-bib target_image tag "iso" "_build_iso/iso.toml")
 
 [group('Build Virtual Machine Image')]
 rebuild-qcow2 $target_image=("localhost/" + image_name) $tag=default_tag: && (_rebuild-bib target_image tag "qcow2" "image.toml")
@@ -153,7 +166,7 @@ rebuild-qcow2 $target_image=("localhost/" + image_name) $tag=default_tag: && (_r
 rebuild-raw $target_image=("localhost/" + image_name) $tag=default_tag: && (_rebuild-bib target_image tag "raw" "image.toml")
 
 [group('Build Virtual Machine Image')]
-rebuild-iso $target_image=("localhost/" + image_name) $tag=default_tag: && (_rebuild-bib target_image tag "iso" "iso.toml")
+rebuild-iso $target_image=("localhost/" + image_name) $tag=default_tag: _render-iso-config && (_rebuild-bib target_image tag "iso" "_build_iso/iso.toml")
 
 _run-vm $target_image $tag $type $config:
     #!/usr/bin/env bash

--- a/iso.toml.in
+++ b/iso.toml.in
@@ -1,7 +1,7 @@
 [customizations.installer.kickstart]
 contents = """
 %post
-bootc switch --mutate-in-place --transport registry ghcr.io/ublue-os/bazzite-dx:latest
+bootc switch --mutate-in-place --transport registry ghcr.io/${IMAGE_VENDOR}/${IMAGE_NAME}:${ISO_REF_TAG}
 %end
 """
 


### PR DESCRIPTION
## Summary

`iso.toml` hardcoded `ghcr.io/ublue-os/bazzite-dx:latest` regardless of which variant was being built. ISOs built for `bazzite-dx-nvidia`, `bazzite-dx-gnome`, or `bazzite-dx-nvidia-gnome` would, after install, run `bootc switch` to the plain `bazzite-dx` image — losing the variant's drivers/desktop on first boot.

## Approach

- Rename `iso.toml` → `iso.toml.in` and replace the hardcoded ref with `${IMAGE_VENDOR}/${IMAGE_NAME}:${ISO_REF_TAG}` placeholders.
- New private Justfile recipe `_render-iso-config` renders the template via `envsubst` into `_build_iso/iso.toml` at build time.
- `build-iso` and `rebuild-iso` now depend on `_render-iso-config` and pass the rendered path to `_build-bib`.
- New `ISO_REF_TAG` env, default `latest` (preserves current behavior).
- `IMAGE_VENDOR` and `IMAGE_NAME` reuse the existing `repo_organization` / `image_name` exports — the same envs that already control the container build.

## Usage

```bash
# default — produces ghcr.io/ublue-os/bazzite-dx:latest, same as before
just build-iso

# variant — set IMAGE_NAME (same env you'd set for the variant container build)
IMAGE_NAME=bazzite-dx-nvidia just build-iso

# alternate channel
ISO_REF_TAG=stable just build-iso
```

## Files Changed

| File | Change |
|---|---|
| `iso.toml` → `iso.toml.in` | renamed; image ref uses `${IMAGE_VENDOR}/${IMAGE_NAME}:${ISO_REF_TAG}` placeholders |
| `Justfile` | +`ISO_REF_TAG` export, +`_render-iso-config` recipe, `build-iso` / `rebuild-iso` rewired to render-then-build |

Total: +16/-3 lines across 2 files.

## Dependencies

Adds `envsubst` (from `gettext`). Standard on Linux dev hosts; if missing, the recipe fails with a clear `command not found`.

Output path `_build_iso/iso.toml` is covered by the existing `.gitignore` `_build_*` rule and the `clean` recipe's `find *_build* -exec rm -rf` glob.

## Testing

Local renders verified before commit:

- [x] Default: `IMAGE_NAME` unset → `ghcr.io/ublue-os/bazzite-dx:latest` (matches prior hardcoded value)
- [x] Variant: `IMAGE_NAME=bazzite-dx-nvidia-gnome` → `ghcr.io/ublue-os/bazzite-dx-nvidia-gnome:latest`
- [x] Vendor + tag override: `GITHUB_REPOSITORY_OWNER=bearyjd ISO_REF_TAG=stable` → `ghcr.io/bearyjd/bazzite-dx-nvidia:stable`
- [x] `just --unstable --fmt --check -f Justfile` passes (project's own `check` recipe)

Reviewers should sanity-check:

- [ ] An NVIDIA ISO actually post-installs to the NVIDIA image (full bib + install run)
- [ ] No surprise interactions with the `_build_*` clean recipe

## Related

None.