### PR TITLE
fix(virt): vendor libvirt qemu hook instead of fetching at runtime

### DIFF
--- a/system_files/usr/share/bazzite-dx/libvirt-hooks/qemu
+++ b/system_files/usr/share/bazzite-dx/libvirt-hooks/qemu
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# vendored from PassthroughPOST/VFIO-Tools
+# source: https://github.com/PassthroughPOST/VFIO-Tools/blob/0e50fd12ece4defba7660b1f2012f9759649ec11/libvirt_hooks/qemu
+# commit: 0e50fd12ece4defba7660b1f2012f9759649ec11 (2025-08-13)
+# license: BSD-2-Clause (see https://github.com/PassthroughPOST/VFIO-Tools/blob/master/LICENSE)
+# to refresh: replace this file from a newer commit and update the metadata above + commit message
+
+#
+# Author: SharkWipf
+#
+# Copy this file to /etc/libvirt/hooks, make sure it's called "qemu".
+# After this file is installed, restart libvirt.
+# From now on, you can easily add per-guest qemu hooks.
+# Add your hooks in /etc/libvirt/hooks/qemu.d/vm_name/hook_name/state_name.
+# For a list of available hooks, please refer to https://www.libvirt.org/hooks.html
+#
+
+GUEST_NAME="$1"
+HOOK_NAME="$2"
+STATE_NAME="$3"
+MISC="${@:4}"
+
+BASEDIR="$(dirname $0)"
+
+HOOKPATH="$BASEDIR/qemu.d/$GUEST_NAME/$HOOK_NAME/$STATE_NAME"
+
+STDIN=$(cat) # Buffer the entirety of stdin so we can pass it on to other scripts. Moderately bad idea, but if the Rust folks can do it so can I.
+
+set -e # If a script exits with an error, we should as well.
+
+# check if it's a non-empty executable file
+if [ -f "$HOOKPATH" ] && [ -s "$HOOKPATH" ] && [ -x "$HOOKPATH" ]; then
+    eval \"$HOOKPATH\" "$@" <<< "$STDIN" # Call the hook with all our arguments and a copy of stdin.
+elif [ -d "$HOOKPATH" ]; then
+    while read file; do
+        # check for null string
+        if [ ! -z "$file" ]; then
+          eval \"$file\" "$@" <<< "$STDIN" # Call each hook with all our arguments and a copy of stdin.
+        fi
+    done <<< "$(find -L "$HOOKPATH" -maxdepth 1 -type f -executable -print;)"
+fi
+

--- a/system_files/usr/share/ublue-os/just/84-bazzite-virt.just
+++ b/system_files/usr/share/ublue-os/just/84-bazzite-virt.just
@@ -64,9 +64,8 @@ setup-virtualization ACTION="":
           echo "Giving qemu access to read ISO files from $HOME"
           sudo setfacl -m u:qemu:rx $HOME
           if sudo test ! -f "/etc/libvirt/hooks/qemu"; then
-            echo "Adding libvirt qemu hooks"
-            sudo wget 'https://raw.githubusercontent.com/PassthroughPOST/VFIO-Tools/master/libvirt_hooks/qemu' -O /etc/libvirt/hooks/qemu
-            sudo chmod +x /etc/libvirt/hooks/qemu
+            echo "Installing libvirt qemu hook (vendored from PassthroughPOST/VFIO-Tools)"
+            sudo install -m 0755 /usr/share/bazzite-dx/libvirt-hooks/qemu /etc/libvirt/hooks/qemu
             sudo grep -A1 -B1 "# Add" /etc/libvirt/hooks/qemu | sed 's/^# //g'
             if sudo test ! -d "/etc/libvirt/hooks/qemu.d"; then
               sudo mkdir /etc/libvirt/hooks/qemu.d


### PR DESCRIPTION
## Summary

`setup-virtualization virt-on` currently fetches `libvirt_hooks/qemu` from `PassthroughPOST/VFIO-Tools/master` via `wget` and `chmod +x`s it into `/etc/libvirt/hooks/qemu`. Libvirt then runs that script as root on every VM lifecycle event. A change to that upstream master branch — accidental or compromised — would silently propagate to every user who runs `virt-on` afterward.

This PR vendors the script into the image at a pinned commit, removing the runtime fetch.

> Note: this PR narrows the **runtime-fetch surface**, not the **hook-execution surface**. The vendored script's `eval` dispatch to `/etc/libvirt/hooks/qemu.d/<vm>/<hook>/<state>` files is upstream-documented behavior — any user with root-write to that directory could already execute code under libvirt's privilege. That contract is unchanged.

## Changes

- **New** `system_files/usr/share/bazzite-dx/libvirt-hooks/qemu` (mode 0755)
  - Vendored from [PassthroughPOST/VFIO-Tools@0e50fd1](https://github.com/PassthroughPOST/VFIO-Tools/blob/0e50fd12ece4defba7660b1f2012f9759649ec11/libvirt_hooks/qemu) (2025-08-13)
  - 1275 bytes, BSD-2-Clause licensed (attribution in header)
  - Provenance header documents source URL, commit SHA, license, and refresh procedure
- **Updated** `system_files/usr/share/ublue-os/just/84-bazzite-virt.just`
  - Replaces `wget … master …` + `chmod +x` with `install -m 0755 /usr/share/bazzite-dx/libvirt-hooks/qemu /etc/libvirt/hooks/qemu`
  - Preserves the existing "don't clobber user-modified hook" guard, the `# Add` hint print, and the `qemu.d/` mkdir step

## Refresh procedure

To pull a newer upstream version:

1. Replace `system_files/usr/share/bazzite-dx/libvirt-hooks/qemu` from the desired commit
2. Update the provenance header (source URL, commit SHA, date)
3. Open a PR — reviewers see the exact diff

## Testing

- [ ] CI builds all 4 variants successfully (Containerfile copies system_files verbatim — preserves the 0755 mode)
- [ ] Reviewer can independently verify content integrity:
  ```bash
  HOOK=system_files/usr/share/bazzite-dx/libvirt-hooks/qemu
  { head -n1 "$HOOK"; tail -n +9 "$HOOK"; } | sha256sum
  # expected: 76a95344ce2d10ccaeda662c9f5f33638fa0f211ab7446a399a1dade5fb65ad9
  curl -fsSL https://raw.githubusercontent.com/PassthroughPOST/VFIO-Tools/0e50fd12ece4defba7660b1f2012f9759649ec11/libvirt_hooks/qemu | sha256sum
  # expected: 76a95344ce2d10ccaeda662c9f5f33638fa0f211ab7446a399a1dade5fb65ad9
  ```
- [ ] On a built image, `ls -l /etc/libvirt/hooks/qemu` does not exist before `setup-virtualization virt-on`, and exists with mode `0755` after
- [ ] `setup-virtualization virt-on` no longer prints a `wget` line
- [ ] Existing `/etc/libvirt/hooks/qemu` (user-modified) is preserved (the guard still applies)
- [ ] `just check` passes (project's own `--fmt --check` recipe lints `*.just` files)

## License attribution

VFIO-Tools is BSD-2-Clause. The required attribution is preserved in the vendored file's header. See https://github.com/PassthroughPOST/VFIO-Tools/blob/master/LICENSE.