### PR TITLE
fix: use established lowercase 'system' ujust group

### DIFF
--- a/system_files/usr/share/ublue-os/just/95-bazzite-dx.just
+++ b/system_files/usr/share/ublue-os/just/95-bazzite-dx.just
@@ -1,7 +1,7 @@
 # vim: set ft=make :
 
 # Configure docker,incus-admin,libvirt, container manager, serial permissions
-[group('System')]
+[group('system')]
 dx-group:
     #!/usr/bin/pkexec bash
     append_group() {


### PR DESCRIPTION
Every other `ujust` command group uses lowercase tags (e.g. "system"), except this one. Current usage of this variant results in it appearing before any other group (excl. ungrouped), as they are sorted alphabetically. If this is intended (e.g. to draw attention to it), it should probably be mentioned in a comment.
