### PR TITLE
chore: remove rocm

### DIFF
--- a/build_files/20-install-apps.sh
+++ b/build_files/20-install-apps.sh
@@ -26,10 +26,6 @@ dnf5 remove -y \
     mesa-libOpenCL
 
 dnf5 --setopt=install_weak_deps=False install -y \
-    rocm-hip \
-    rocm-opencl \
-    rocm-clinfo \
-    rocm-smi \
     qemu \
     libvirt \
     qemu-kvm \


### PR DESCRIPTION
As far as I am aware, rocm is almost always installed in a container, making its use on a host image quite rare. Even pytorch from pip installs rocm (Tested on bazzite no dx).