### PR TITLE
chore: copy entries into /usr/lib's passwd and group

### DIFF
--- a/build_files/999-cleanup.sh
+++ b/build_files/999-cleanup.sh
@@ -21,6 +21,39 @@ rm -rf /var
 mkdir -p /var/tmp
 chmod -R 1777 /var/tmp
 
+# Copy entries into /usr/lib/passwd and /usr/lib/group
+if [ -f /etc/passwd ]; then
+    out=$(grep -v "root" /etc/passwd) || true
+    if [ -n "$out" ]; then
+        echo
+        echo Moving the following passwd users to /usr/lib/passwd
+        echo "$out"
+        echo "$out" >> /usr/lib/passwd
+        echo "root:x:0:0:root:/root:/bin/bash" > /etc/passwd
+    fi
+fi
+if [ -f /etc/group ]; then
+    out=$(grep -v "root\|wheel" /etc/group) || true
+    if [ -n "$out" ]; then
+        echo
+        echo Moving the following group entries to /usr/lib/group
+        echo "$out"
+        echo "$out" >> /usr/lib/group
+        echo "root:x:0:" > /etc/group
+        echo "wheel:x:10:" >> /etc/group
+    fi
+fi
+
+# Extra lock files created by container processes that might cause issues
+rm -rf \
+    /etc/.pwd.lock \
+    /etc/passwd- \
+    /etc/group- \
+    /etc/shadow- \
+    /etc/gshadow- \
+    /etc/subuid- \
+    /etc/subgid-
+
 # Commit and lint container
 bootc container lint || true
 


### PR DESCRIPTION
Maybe that was preventing Docker from starting up after rebasing from Bazzite