### PR TITLE
fix: clean up 20-install-apps.sh

### DIFF
--- a/build_files/20-install-apps.sh
+++ b/build_files/20-install-apps.sh
@@ -85,12 +85,9 @@ dnf5 install --enable-repo="copr:copr.fedorainfracloud.org:ublue-os:packages" -y
 # over using random coprs. Please keep this in mind when adding external dependencies.
 # If adding any dependency, make sure to always have it disabled by default and _only_ enable it on `dnf install`
 
-dnf5 config-manager addrepo --set=baseurl="https://packages.microsoft.com/yumrepos/vscode" --id="vscode"
-dnf5 config-manager setopt vscode.enabled=0
-# FIXME: gpgcheck is broken for vscode due to it using `asc` for checking
-# seems to be broken on newer rpm security policies.
-dnf5 config-manager setopt vscode.gpgcheck=0
-dnf5 install --nogpgcheck --enable-repo="vscode" -y \
+dnf5 config-manager addrepo --from-repofile="https://packages.microsoft.com/yumrepos/vscode/config.repo"
+dnf5 config-manager setopt vscode-yum.enabled=0
+dnf5 install --enable-repo="vscode-yum" -y \
     code
 
 docker_pkgs=(
@@ -102,13 +99,7 @@ docker_pkgs=(
 )
 dnf5 config-manager addrepo --from-repofile="https://download.docker.com/linux/fedora/docker-ce.repo"
 dnf5 config-manager setopt docker-ce-stable.enabled=0
-dnf5 install -y --enable-repo="docker-ce-stable" "${docker_pkgs[@]}" || {
-    # Use test packages if docker pkgs is not available for f42
-    if (($(lsb_release -sr) == 42)); then
-        echo "::info::Missing docker packages in f42, falling back to test repos..."
-        dnf5 install -y --enablerepo="docker-ce-test" "${docker_pkgs[@]}"
-    fi
-}
+dnf5 install -y --enable-repo="docker-ce-stable" "${docker_pkgs[@]}"
 
 # Load iptable_nat module for docker-in-docker.
 # See:


### PR DESCRIPTION
This PR cleans up the install-apps script by using official repofile for vscode and installing stable docker engine instead of test.

_The commits in this PR were AI assisted, but reviewed and tested._