### PR TITLE
fix: Install Noto Sans for VSCode

### DIFF
--- a/build_files/20-install-apps.sh
+++ b/build_files/20-install-apps.sh
@@ -9,6 +9,7 @@ dnf5 install -y \
     ccache \
     flatpak-builder \
     git-subtree \
+    google-noto-sans-fonts \
     nicstat \
     numactl \
     podman-machine \


### PR DESCRIPTION
Fixes #156 

VSCode is installed via the `code` RPM, which declares no font dependency. Without a plain sans-serif font, its Electron UI can render a black/unresponsive window.

This has been successfully tested locally in a VM.