### PR TITLE
ci: migrate build job to Ubuntu 26.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   build_push:
     name: Build and push image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- migrate the Bazzite DX image build job from Ubuntu 24.04 to Ubuntu 26.04

## Root cause

This is likely the root-cause fix for ublue-os/bazzite#5604. The Ubuntu 24.04 runner image bundles fuse-overlayfs 1.16, which can silently change the Buildah storage backend and correlates with filesystem/image corruption. The trailing NUL bytes reported in https://github.com/ublue-os/bazzite/issues/5604 are understood to be a symptom of that corruption. Moving the build job to Ubuntu 26.04 avoids the affected runner environment.

## Validation

- parsed `.github/workflows/build.yml` successfully
- ran `git diff --check`